### PR TITLE
Feature guzzle params editable

### DIFF
--- a/src/AbstractApi.php
+++ b/src/AbstractApi.php
@@ -20,11 +20,19 @@ abstract class AbstractApi
 
     protected $tries = 0;
 
-    public function __construct(Api $api, array $access)
+    /**
+     * Parameters to be added for guzzle.
+     *
+     * @var array
+     */
+    protected $parameters = [];
+
+    public function __construct(Api $api, array $access, array $parameters = [])
     {
         $this->access = $access;
         $this->api = $api;
         $this->debug = $access['debug'] ?? false;
+        $this->parameters = $parameters;
     }
 
     protected function getClient(string $path) {
@@ -41,12 +49,15 @@ abstract class AbstractApi
 
         $stack->push($middleware);
 
-        return new Client([
+        $baseParameters = [
             'auth'      => 'oauth',
             'base_uri'  => $this->access['url'],
             'handler'   => $stack,
             'timeout'   => 10.0,
-        ]);
+        ];
+        $parameters = array_merge($baseParameters, $this->parameters);
+
+        return new Client($parameters);
     }
 
     protected function _delete(string $path, array $parameters = [])

--- a/src/Api.php
+++ b/src/Api.php
@@ -17,19 +17,19 @@ class Api
     protected $requestLimitMax = 0;
     protected $requestLimitCount = 0;
 
-    public function __construct(array $access)
+    public function __construct(array $access, array $parameters = [])
     {
         $access['url'] = $this->getUrl($access['url'] ?? '');
 
-        $this->access = new Access($this, $access);
-        $this->account = new Account($this, $access);
-        $this->expansion = new Expansion($this, $access);
-        $this->games = new Games($this, $access);
-        $this->messages = new Messages($this, $access);
-        $this->order = new Order($this, $access);
-        $this->priceguide = new Priceguide($this, $access);
-        $this->product = new Product($this, $access);
-        $this->stock = new Stock($this, $access);
+        $this->access = new Access($this, $access, $parameters);
+        $this->account = new Account($this, $access, $parameters);
+        $this->expansion = new Expansion($this, $access, $parameters);
+        $this->games = new Games($this, $access, $parameters);
+        $this->messages = new Messages($this, $access, $parameters);
+        $this->order = new Order($this, $access, $parameters);
+        $this->priceguide = new Priceguide($this, $access, $parameters);
+        $this->product = new Product($this, $access, $parameters);
+        $this->stock = new Stock($this, $access, $parameters);
     }
 
     public function setRequestLimitCount(int $limit) : void


### PR DESCRIPTION
Hello,

I have finally worked a bit on Your API today :-)
Currently I have an issue with the timeout, even the recent change to 10 secs is not enough when getting the "Mystery Booster" singles from the expansion. I want to increase the timeout further for that.

I thought it may be a good thing to make the Guzzle params configurable.
I would really appreciate if You could merge this change. If you need anything else or if I did something wrong, please don't hesitate to ask me for.

Best regards, Martin